### PR TITLE
M0 #21: KiCadプロジェクト初期化（フォルダ構成・ライブラリ方針・命名規約）

### DIFF
--- a/docs/kicad_git_workflow.md
+++ b/docs/kicad_git_workflow.md
@@ -10,12 +10,10 @@
 推奨構成（例）：
 
 hw/
-<proj>.kicad_pro
-step00_top.kicad_sch
+hw.kicad_pro
+hw.kicad_sch
 step01_power.kicad_sch
-step02_io_.kicad_sch
-step03_.kicad_sch
-(必要になったら) <proj>.kicad_pcb
+(必要になったら) hw.kicad_pcb
 (必要になったら) sym-lib-table
 (必要になったら) fp-lib-table
 lib/ # 外部ライブラリは必要時のみ（追加は別Issue）
@@ -52,7 +50,7 @@ KiCadはGUI編集だが、主要成果物はテキストファイルでありGit
 ### 3.1 分割方針（Step01〜）
 原則：回路図はStep単位のファイルに分割し、変更範囲を小さくする。
 
-- `step00_top.kicad_sch`：最上位（俯瞰と階層シートの接続点）
+- `hw.kicad_sch`：Step00（最上位／俯瞰と階層シートの接続点）
 - `step01_power.kicad_sch`：電源（W3でこのファイルを作る方針）
 - `step02_*`：I/OやTOSLINK周辺
 - `step03_*`：MCU周り
@@ -68,12 +66,12 @@ KiCadはGUI編集だが、主要成果物はテキストファイルでありGit
   - 基板ファイルは担当者固定、または順番制（同時編集禁止）
 
 ### 3.3 Step00への統合ルール（参照の追加）
-- Step01〜を作っただけではStep00に自動反映されないため、**統合は `step00_top.kicad_sch` に階層シート参照を追加して行う**
-- `step00_top.kicad_sch` は統合点なので、**同時編集禁止**（衝突回避）
+- Step01〜を作っただけではStep00に自動反映されないため、**統合は `hw.kicad_sch` に階層シート参照を追加して行う**
+- `hw.kicad_sch` は統合点なので、**同時編集禁止**（衝突回避）
 
 **推奨運用（統合PR方式）**
-- 各Step作成PR（例：`step01_power.kicad_sch` 追加/更新）では **`step00_top.kicad_sch` を触らない**
-- Stepが揃ったタイミングで、最後に **「統合PR」** を作り、`step00_top.kicad_sch` に **参照（階層シート）をまとめて追加**する
+- 各Step作成PR（例：`step01_power.kicad_sch` 追加/更新）では **`hw.kicad_sch` を触らない**
+- Stepが揃ったタイミングで、最後に **「統合PR」** を作り、`hw.kicad_sch` に **参照（階層シート）をまとめて追加**する
 
 注意：
 - ここでの「統合」は **KiCadでの参照追加**であり、**KiCad上でファイル同士を“マージ”する操作はしない**
@@ -100,7 +98,7 @@ KiCadはGUI編集だが、主要成果物はテキストファイルでありGit
 - 1つのPRでは基本1つのStepファイル（例：step01_power）だけを変更する
 - PRが承認されたらGitHub上でマージして積み上げる
   - KiCad上で“マージ”操作はしない
-- まとめて最後に統合する運用ではなく、順次マージで前進する
+- Stepファイル（step01/step02…）は順次マージで前進し、Step00（hw.kicad_sch）への参照追加は「統合PR」でまとめて行う
 
 ### 5.2 PRに必ず添付する“証跡”（Evidence）
 GUI編集のため、差分だけだとレビューが難しい。  

--- a/hw/hw.kicad_pcb
+++ b/hw/hw.kicad_pcb
@@ -1,0 +1,2 @@
+(kicad_pcb (version 20241229) (generator "pcbnew") (generator_version "9.0")
+)

--- a/hw/hw.kicad_pro
+++ b/hw/hw.kicad_pro
@@ -1,0 +1,83 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {},
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "rules": {},
+      "track_widths": [],
+      "via_dimensions": []
+    },
+    "ipc2581": {
+      "dist": "",
+      "distpn": "",
+      "internal_id": "",
+      "mfg": "",
+      "mpn": ""
+    },
+    "layer_pairs": [],
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "hw.kicad_pro",
+    "version": 3
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.2,
+        "via_diameter": 0.6,
+        "via_drill": 0.3,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 4
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {
+      "gencad": "",
+      "idf": "",
+      "netlist": "",
+      "plot": "",
+      "pos_files": "",
+      "specctra_dsn": "",
+      "step": "",
+      "svg": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "legacy_lib_dir": "",
+    "legacy_lib_list": []
+  },
+  "sheets": [],
+  "text_variables": {}
+}

--- a/hw/hw.kicad_sch
+++ b/hw/hw.kicad_sch
@@ -1,0 +1,14 @@
+(kicad_sch
+	(version 20250114)
+	(generator "eeschema")
+	(generator_version "9.0")
+	(uuid 7b66d93d-d6d0-4bd4-83b3-6fc711e21073)
+	(paper "A4")
+	(lib_symbols)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
+	(embedded_fonts no)
+)


### PR DESCRIPTION
## 何をしたか（What）
- hw/ 配下に KiCad プロジェクト初期ファイルを追加（hw.kicad_pro / hw.kicad_sch / hw.kicad_pcb）
- docs/kicad_git_workflow.md を追加し、Step分割命名・ライブラリ運用方針を明文化

## なぜ必要か（Why）
- Issue #21 の受け入れ条件（プロジェクト骨格固定、命名規約・運用ルールの明文化）を満たすため

## テストしたか（Evidence: ログ/スクショ）
- [x] 手動テスト（手順：ACチェック実施）
- [ ] 自動テスト（コマンド：N/A）
- [x] ログ添付（リンク/貼付）：git diff --name-only origin/main...HEAD で差分確認
- [ ] スクショ/波形/測定結果（必要なら添付）
- AC結果: AC_GATE: PASS

## 影響範囲（Impact）
- [x] hw
- [ ] fw
- [ ] tools
- [x] docs
- [ ] test
- 互換性への影響：なし
- 影響が出る可能性のある箇所：KiCadファイル運用ルール

## 関連Issue
- Closes #21

## チェックリスト（DoD）
- [x] 変更理由が説明できる（Whyが書けている）
- [x] 証拠（ログ/スクショ/測定結果）がある
- [x] 必要な docs が更新されている
- [x] 回帰テストが追加/更新されている（該当する場合）