### PR TITLE
docs: add bringup voltage expectations for testpoints

### DIFF
--- a/docs/bringup.md
+++ b/docs/bringup.md
@@ -52,6 +52,23 @@
 - 黒プローブ：Pico GND
 - 赤プローブ：3.3Vレール（または Tx/Rx の VCC ピン）
 
+### 2.3 電源Bring-up（テスター）
+測定手順（最小）
+- DMMをDC電圧レンジに設定
+- 黒リードを TP2（TP_GND）に当て続ける（基準点）
+- 赤リードで各TPを測る
+
+| TP（Reference/Value） | Net | 期待値（レンジ） | 判定/メモ |
+| --- | --- | --- | --- |
+| TP2（TP_GND） | GND | 0 V | 基準点。0 Vからずれる場合はGND接続を再確認 |
+| TP1（TP_VBUS） | VBUS_IN | 4.75-5.25 V | USB 5 V入力。範囲内ならOK |
+| TP4（TP_VBUS_PRO） | VBUS_PRO | 4.75-5.25 V | 保護後5 V。範囲内ならOK |
+| TP3（TP_3V3） | 3V3 | 3.23-3.37 V | 3.3 Vレール。範囲内ならOK |
+
+切り分けメモ
+- TP1がOKでTP4がNGなら、F1（Polyfuse）周り（はんだ不良/部品不良/トレース）を疑う
+- TP4がOKでTP3がNGなら、LDO（U1）周り（向き/はんだ/短絡/入出力コンデンサ）を疑う
+
 ---
 
 ## 3. Phase 2: MCU（Pico動作）


### PR DESCRIPTION
## 何をしたか（What）
- docs/bringup.md にテストポイント（TP_VBUS / TP_VBUS_PRO / TP_3V3 / TP_GND）と期待電圧レンジを対応づけて追記した
- DMM（テスター）での測定手順と、異常時の簡易切り分けメモを追加した

## なぜ必要か（Why）
- オシロ無しでも電源の合否判定を再現可能にし、Bring-upの属人化を減らすため
- TP名と期待値が紐づいていないと、現場で判断基準がぶれて再検証コストが増えるため

## テストしたか（Evidence: ログ/スクショ）
- [x] 手動テスト（手順：docs/bringup.md の「電源Bring-up（DMM）」セクションに TP と期待値レンジが揃っていることを確認）
- [ ] 自動テスト（コマンド：なし。docsのみ変更）
- [x] ログ添付（リンク/貼付）：
  - git diff（PRのFiles changedで確認可能）
- [ ] スクショ/波形/測定結果（必要なら添付）

## 影響範囲（Impact）
- [ ] hw
- [ ] fw
- [ ] tools
- [x] docs
- [ ] test
- 互換性への影響：なし
- 影響が出る可能性のある箇所：docs/bringup.md の手順参照者のみ

## 関連Issue
- Closes #23 

## チェックリスト（DoD）
- [x] 変更理由が説明できる（Whyが書けている）
- [x] 証拠（ログ/スクショ/測定結果）がある（docs確認 + diff）
- [x] 必要な docs が更新されている
- [x] 回帰テストが追加/更新されている（該当する場合）