### PR TITLE
ci: add standalone kicad PR guard workflow

### DIFF
--- a/.github/workflows/kicad-pr-guard.yml
+++ b/.github/workflows/kicad-pr-guard.yml
@@ -1,0 +1,102 @@
+name: KiCad PR guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    name: Validate KiCad PR rules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Evaluate changed files against KiCad rules
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          echo "base=$BASE_SHA"
+          echo "head=$HEAD_SHA"
+          echo "labels=$PR_LABELS"
+
+          CHANGED="$(mktemp)"
+          git diff --name-status --find-renames "$BASE_SHA" "$HEAD_SHA" > "$CHANGED"
+
+          echo "::group::Changed files (name-status)"
+          cat "$CHANGED"
+          echo "::endgroup::"
+
+          is_integration_pr=false
+          if echo ",$PR_LABELS," | grep -q ",integration-pr,"; then
+            is_integration_pr=true
+          fi
+          echo "integration_pr=$is_integration_pr"
+
+          fail=0
+          errors=()
+
+          while IFS=$'\t' read -r status path1 path2; do
+            [ -n "${status:-}" ] || continue
+
+            path="$path1"
+            if [[ "$status" =~ ^R[0-9]+$ ]]; then
+              path="$path2"
+            fi
+
+            # Ignore pure deletions for "mixed-in" checks.
+            if [[ "$status" == "D" ]]; then
+              continue
+            fi
+
+            base_name="$(basename "$path")"
+
+            # 1) Forbidden files/dirs mixed into PR
+            if [[ "$path" == *.kicad_prl ]] \
+              || [[ "$path" == *-backups/* ]] \
+              || [[ "$base_name" == _autosave-* ]] \
+              || [[ "$path" == *.lck ]] \
+              || [[ "$path" == out/* ]] \
+              || [[ "$path" == hw/out/* ]]; then
+              errors+=("Forbidden file/directory detected: ${path} (${status})")
+              fail=1
+            fi
+
+            # 2) Step schematic naming rule for Added/Renamed only
+            if [[ "$status" == "A" || "$status" =~ ^R[0-9]+$ ]]; then
+              if [[ "$path" == hw/*.kicad_sch ]]; then
+                if [[ "$path" == "hw/hw.kicad_sch" || "$path" == "hw/step00_top.kicad_sch" ]]; then
+                  :
+                elif [[ ! "$path" =~ ^hw/step[0-9]{2}_[a-z0-9_]+\.kicad_sch$ ]]; then
+                  errors+=("Invalid step schematic filename (A/R only): ${path} (expected: hw/stepNN_*.kicad_sch)")
+                  fail=1
+                fi
+              fi
+            fi
+
+            # 3) Step00 change is only allowed for integration PR
+            if [[ "$path" == "hw/hw.kicad_sch" || "$path" == "hw/step00_top.kicad_sch" ]]; then
+              if [[ "$is_integration_pr" != true ]]; then
+                errors+=("Step00 change is only allowed with label 'integration-pr': ${path} (${status})")
+                fail=1
+              fi
+            fi
+          done < "$CHANGED"
+
+          if [[ "$fail" -ne 0 ]]; then
+            echo "KiCad PR guard failed:"
+            printf ' - %s\n' "${errors[@]}"
+            exit 1
+          fi
+
+          echo "KiCad PR guard passed."


### PR DESCRIPTION
## 何をしたか（What）
- `.github/workflows/kicad-pr-guard.yml` を追加
- PR差分を対象に、KiCad関連ガード（禁止ファイル/Step命名/Step00編集条件）を評価する単独workflowを追加

## なぜ必要か（Why）
- PR時に差分ベースでガードを掛け、レビュー前にルール逸脱を検知するため

## テストしたか（Evidence: ログ/スクショ）
> “動いた” ではなく **何をどう確認したか** を残す。
- [x] 手動テスト（手順：）
- [ ] 自動テスト（コマンド：）
- [x] ログ添付（リンク/貼付）：
  - `BASE_SHA/HEAD_SHA` と `git diff --name-status` を入力に `scripts/ci/kicad_pr_guard.sh` をローカル実行し、T1〜T5相当ケースの戻り値を確認
  - 期待結果: T1/T2/T3/T4 fail, integration-pr ラベル時の許可ケース pass
- [ ] スクショ/波形/測定結果（必要なら添付）

## 影響範囲（Impact）
- [ ] hw
- [ ] fw
- [ ] tools
- [x] docs
- [x] test
- 互換性への影響：なし
- 影響が出る可能性のある箇所：PR時のCI（追加workflow）

## 関連Issue
- Closes #

## チェックリスト（DoD）
- [x] 変更理由が説明できる（Whyが書けている）
- [x] 証拠（ログ/スクショ/測定結果）がある
- [x] 必要な docs が更新されている
- [x] 回帰テストが追加/更新されている（該当する場合）