### PR TITLE
chore: ignore local artifacts and add PR template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,81 @@
 # =========================================
+# Local workspace (do NOT commit)
+# =========================================
+.worktrees/
+.claude/
+
+# Optional: local scratch
+.tmp/
+temp/
+.cache/
+
+# =========================================
+# OS / editor noise
+# =========================================
+.DS_Store
+Thumbs.db
+Desktop.ini
+*.stackdump
+
+.vscode/
+.idea/
+*.swp
+*.swo
+*.tmp
+*.bak
+
+# =========================================
+# Logs
+# =========================================
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# =========================================
+# Python
+# =========================================
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.venv/
+venv/
+ENV/
+.envrc
+
+# =========================================
+# Node / TypeScript (if used)
+# =========================================
+node_modules/
+dist/
+build/
+coverage/
+.turbo/
+.eslintcache
+*.eslintcache
+*.tsbuildinfo
+.next/
+out/
+.expo/
+.expo-shared/
+
+# =========================================
+# Env files (never commit secrets)
+# =========================================
+.env
+.env.*
+**/.env
+**/.env.*
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# =========================================
 # Build artifacts (C/C++/embedded general)
 # =========================================
-
 # Prerequisites
 *.d
 
@@ -58,11 +132,9 @@ dkms.conf
 # debug information files
 *.dwo
 
-
 # =========================================
 # KiCad: user/local state (do NOT commit)
 # =========================================
-
 # Project local UI state (window positions, recent files, etc.)
 *.kicad_prl
 
@@ -78,38 +150,4 @@ _autosave-*
 *.lck
 
 # KiCad backup folders (common pattern)
-*-backups/
-_backups/
-backups/
-
-# KiCad caches
-fp-info-cache
-
-
-# =========================================
-# Outputs (generated artifacts)
-# =========================================
-
-# Generic output folder(s)
-out/
-hw/out/
-
-# Common manufacturing/export outputs (if they appear)
-gerbers/
-gerber/
-fabrication/
-manufacturing/
-exports/
-export/
-
-
-# =========================================
-# OS / editor noise
-# =========================================
-
-.DS_Store
-Thumbs.db
-Desktop.ini
-
-.vscode/
-.idea/
+*-back*


### PR DESCRIPTION
﻿## 何をしたか（What）
- .gitignore を整備して、ローカル作業で発生する不要ファイル（.claude/、.worktrees/、KiCadバックアップ/ロック、out/ など）を追跡対象から除外した
- .github/pull_request_template.md を追加して、PR本文の構造（What/Why/Evidence/Impact/Issue/DoD）を統一した

## なぜ必要か（Why）
- ローカル環境依存の差分がPRに混入するとレビューと原因追跡が壊れ、再現性が落ちる
- PR本文の型を固定して、レビュー観点の漏れと曖昧な報告を防ぐ

## テストしたか（Evidence: ログ/スクショ）
> “動いた” ではなく 何をどう確認したか を残す。
- [x] 手動テスト（手順：`git status` で不要ファイルが追跡されないことを確認）
- [x] 自動テスト（コマンド：`git check-ignore -v .claude/ .worktrees/ hw/out/`）
- [ ] ログ添付（リンク/貼付）：
- [ ] スクショ/波形/測定結果（必要なら添付）

## 影響範囲（Impact）
- [x] hw
- [ ] fw
- [ ] tools
- [x] docs
- [ ] test
- 互換性への影響：なし
- 影響が出る可能性のある箇所：これまで誤って追跡していたローカル生成物が差分に出なくなる（意図どおり）

## 関連Issue
- Closes #

## チェックリスト（DoD）
- [x] 変更理由が説明できる（Whyが書けている）
- [x] 証拠（ログ/スクショ/測定結果）がある
- [x] 必要な docs が更新されている
- [x] 回帰テストが追加/更新されている（該当する場合）
